### PR TITLE
fixes plain text url-link display

### DIFF
--- a/pi1/class.tx_directmail_pi1.php
+++ b/pi1/class.tx_directmail_pi1.php
@@ -693,7 +693,7 @@ class tx_directmail_pi1 extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 		} elseif (substr($theLink,0,4) != 'http') {
 			$theLink = $this->siteUrl.$theLink;
 		}
-		return $this->cObj->getCurrentVal().' (###LINK_PREFIX### '.$theLink.' )';
+		return $this->cObj->getCurrentVal().' (###LINK_PREFIX### '.$theLink.')';
 	}
 
 	/**


### PR DESCRIPTION
There was a blank between link url and closing bracket which is now deleted so that it looks nicer.
