### PR TITLE
[BUGFIX] Make DirectMailUtility::getFEgroupSubgroups static

### DIFF
--- a/Classes/DirectMailUtility.php
+++ b/Classes/DirectMailUtility.php
@@ -863,7 +863,7 @@ class DirectMailUtility
      *
      * @return array The all id of fe_groups
      */
-    public function getFEgroupSubgroups($groupId)
+    public static function getFEgroupSubgroups($groupId)
     {
         // get all subgroups of this fe_group
         // fe_groups having this id in their subgroup field


### PR DESCRIPTION
The method is called static, which implies it should be static, since
it also doesnt depend on initialized fields.

This fixes an issue where a deprecation notice could trigger the
configured exception handler.
